### PR TITLE
Fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Agui uses the CMAKE build system.
 
 Currently Allegro5 and SFML2 backends are implemented and supported.
 
-Agui is used in Stemwater Spades https://github.com/jmasterx/StemwaterSpades and the popular commercial game Factorio: http://www.factorio.com/credits
+Agui is used in Stemwater Spades https://github.com/jmasterx/StemwaterSpades and the popular commercial game Factorio: https://www.factorio.com/game/about


### PR DESCRIPTION
The old /credits link was removed from the Factorio website and no longer works.